### PR TITLE
Fix key collision in NotFilledInSection (#59)

### DIFF
--- a/app/components/ReportSections.tsx
+++ b/app/components/ReportSections.tsx
@@ -189,7 +189,7 @@ export function NotFilledInSection({ items }: { items: NotFilledInItem[] }) {
     >
       {items.map((c) => (
         <Row
-          key={c.accountNumber}
+          key={`${c.accountNumber}|${c.description}`}
           tone="info"
           f={c.description}
           m={`${c.institution}${c.accountNumber ? ` · ${c.accountNumber}` : ""}`}

--- a/lib/categorizer.test.ts
+++ b/lib/categorizer.test.ts
@@ -82,6 +82,73 @@ describe("categorize — basic assembly", () => {
   });
 });
 
+// ─── notFilledIn deduplication ──────────────────────────────────────────────
+
+describe("categorize — notFilledIn deduplication", () => {
+  it("keeps two entries with the same accountNumber but different descriptions", () => {
+    const makeAccountEntry = (accountNumber: string, description: string, balance: number) => ({
+      accountNumber,
+      description,
+      amounts: { bank: { balance } },
+    });
+
+    const statement: AnnualStatementData = {
+      institution: "ING",
+      institutionType: "bank",
+      taxYear: 2024,
+      metadata: {},
+      accounts: [
+        makeAccountEntry("NL00INGB0000000001", "Betaalrekening", 1000),
+        makeAccountEntry("NL00INGB0000000001", "Spaarrekening", 2000),
+      ],
+    };
+
+    const result = categorize(
+      makeMatchResult({
+        onlyInJaaropgave: [
+          { statement, account: statement.accounts[0] },
+          { statement, account: statement.accounts[1] },
+        ],
+      })
+    );
+
+    expect(result.notFilledIn).toHaveLength(2);
+    const descriptions = result.notFilledIn.map((n) => n.description);
+    expect(descriptions).toContain("Betaalrekening");
+    expect(descriptions).toContain("Spaarrekening");
+  });
+
+  it("deduplicates two entries with the same accountNumber AND same description", () => {
+    const makeAccountEntry = (accountNumber: string, description: string, balance: number) => ({
+      accountNumber,
+      description,
+      amounts: { bank: { balance } },
+    });
+
+    const statement: AnnualStatementData = {
+      institution: "ING",
+      institutionType: "bank",
+      taxYear: 2024,
+      metadata: {},
+      accounts: [
+        makeAccountEntry("NL00INGB0000000001", "Betaalrekening", 1000),
+        makeAccountEntry("NL00INGB0000000001", "Betaalrekening", 1000),
+      ],
+    };
+
+    const result = categorize(
+      makeMatchResult({
+        onlyInJaaropgave: [
+          { statement, account: statement.accounts[0] },
+          { statement, account: statement.accounts[1] },
+        ],
+      })
+    );
+
+    expect(result.notFilledIn).toHaveLength(1);
+  });
+});
+
 // ─── €1 tolerance ───────────────────────────────────────────────────────────
 
 describe("categorize — €1 tolerance", () => {

--- a/lib/categorizer.ts
+++ b/lib/categorizer.ts
@@ -131,7 +131,7 @@ export function categorize(matchResult: MatchResult): CategorizationResult {
   return {
     covered: dedupeBy(covered, (c) => `${c.accountNumber}|${c.field}`),
     missingStatement: dedupeBy(missingStatement, (m) => `${m.accountNumber}|${m.field}`),
-    notFilledIn: dedupeBy(notFilledIn, (n) => n.accountNumber),
+    notFilledIn: dedupeBy(notFilledIn, (n) => `${n.accountNumber}|${n.description}`),
     amountMismatches,
   };
 }


### PR DESCRIPTION
Fixes #59.

## Summary

- `NotFilledInSection` row key changed from `c.accountNumber` to `${c.accountNumber}|${c.description}` to match the pattern used in sibling sections
- `categorizer.ts` deduplication key for `notFilledIn` updated to match
- Two new tests: same account number with different descriptions (both survive), same account number with same description (deduplicated)

All 108 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)