### PR TITLE
Make section collapse header a button with aria-expanded (#60)

### DIFF
--- a/app/components/ReportSections.tsx
+++ b/app/components/ReportSections.tsx
@@ -96,7 +96,7 @@ function Section({
   if (count === 0) return null;
   return (
     <div id={id} className={`sec tone-${tone}`}>
-      <div className={`sechead${open ? "" : " collapsed"}`} onClick={() => setOpen((v) => !v)}>
+      <button type="button" aria-expanded={open} className={`sechead${open ? "" : " collapsed"}`} onClick={() => setOpen((v) => !v)}>
         <span className="chip">
           <Icon name={icon} size={16} />
         </span>
@@ -113,7 +113,7 @@ function Section({
             style={{ transform: open ? "rotate(0deg)" : "rotate(-90deg)" }}
           />
         </div>
-      </div>
+      </button>
       {open && children}
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -397,6 +397,17 @@ button.stat:disabled {
   color: var(--c);
 }
 .irow .label-col { min-width: 0; }
+button.sechead {
+  appearance: none;
+  text-align: left;
+  width: 100%;
+  font: inherit;
+  cursor: pointer;
+}
+button.sechead:focus-visible {
+  outline: 2px solid var(--c);
+  outline-offset: -2px;
+}
 .sechead-actions {
   margin-left: auto;
   display: flex;


### PR DESCRIPTION
Fixes #60.

## Summary

- Replaced `<div onClick>` collapse trigger in `Section` with a `<button type="button">`
- Added `aria-expanded={open}` for assistive technology
- Toggle is now keyboard-reachable (Tab + Enter/Space)

🤖 Generated with [Claude Code](https://claude.com/claude-code)