### PR TITLE
Remove boolean | undefined return from analyzeIncremental (#62)

### DIFF
--- a/app/components/IncrementalCard.tsx
+++ b/app/components/IncrementalCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { Icon } from "../Icon";
 import { DropZone } from "./DropZone";
 import { AnalysisProgress } from "./AnalysisProgress";
@@ -12,15 +12,22 @@ export function IncrementalCard({
 }: {
   loading: boolean;
   error: string | null;
-  onSubmit: (files: File[]) => Promise<boolean | undefined>;
+  onSubmit: (files: File[]) => Promise<void>;
 }) {
   const [files, setFiles] = useState<File[]>([]);
+  const prevLoading = useRef(false);
+
+  useEffect(() => {
+    if (prevLoading.current && !loading && !error) {
+      setFiles([]);
+    }
+    prevLoading.current = loading;
+  }, [loading, error]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!files.length || loading) return;
-    const ok = await onSubmit(files);
-    if (ok) setFiles([]);
+    await onSubmit(files);
   }
 
   return (

--- a/app/hooks/useAnalysis.ts
+++ b/app/hooks/useAnalysis.ts
@@ -50,7 +50,7 @@ export function useAnalysis(apiKey: string) {
     }
   }
 
-  async function analyzeIncremental(files: File[]): Promise<boolean | undefined> {
+  async function analyzeIncremental(files: File[]): Promise<void> {
     if (!extractedData) return;
     const controller = new AbortController();
     abortRef.current = controller;
@@ -75,7 +75,6 @@ export function useAnalysis(apiKey: string) {
       const data = AnalyseResponseSchema.parse(await res.json());
       setReport(data.report);
       setExtractedData(data.extractedData);
-      return true;
     } catch (err) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       setIncrementalError(


### PR DESCRIPTION
Fixes #62.

## Summary

- `analyzeIncremental` now returns `Promise<void>`
- `IncrementalCard` uses a `useEffect` with a `prevLoading` ref to detect the success transition (`loading` flips `true → false` with no `error`) and resets file input accordingly
- `onSubmit` prop type updated to `(files: File[]) => Promise<void>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)