### PR TITLE
Replace document.getElementById scroll with anchor links (#64)

### DIFF
--- a/app/components/ReportSections.tsx
+++ b/app/components/ReportSections.tsx
@@ -18,49 +18,45 @@ export function SummaryBoxes({ report }: { report: AnalysisReport }) {
     icon: Parameters<typeof Icon>[0]["name"];
     count: number;
     label: string;
-    targetId: string;
+    href: string;
   }[] = [
     {
       tone: "pos",
       icon: "check",
       count: report.covered.length,
       label: "Gedekt",
-      targetId: "section-gedekt",
+      href: "#section-gedekt",
     },
     {
       tone: "warn",
       icon: "alert",
       count: report.missingStatement.length,
       label: "Jaaropgave ontbreekt",
-      targetId: "section-ontbreekt",
+      href: "#section-ontbreekt",
     },
     {
       tone: "info",
       icon: "file-plus",
       count: report.notFilledIn.length,
       label: "Niet ingevuld",
-      targetId: "section-niet-ingevuld",
+      href: "#section-niet-ingevuld",
     },
     {
       tone: "attn",
       icon: "flag",
       count: report.attentionPoints.length,
       label: "Aandachtspunten",
-      targetId: "section-aandachtspunten",
+      href: "#section-aandachtspunten",
     },
   ];
   return (
     <div className="statrow">
       {items.map((s) => (
-        <button
+        <a
           key={s.label}
+          href={s.count > 0 ? s.href : undefined}
+          aria-disabled={s.count === 0}
           className={`stat tone-${s.tone}`}
-          onClick={() =>
-            document
-              .getElementById(s.targetId)
-              ?.scrollIntoView({ behavior: "smooth", block: "start" })
-          }
-          disabled={s.count === 0}
         >
           <div className="stat-top">
             <span className="chip">
@@ -69,7 +65,7 @@ export function SummaryBoxes({ report }: { report: AnalysisReport }) {
             <div className="n num">{s.count}</div>
           </div>
           <div className="l">{s.label}</div>
-        </button>
+        </a>
       ))}
     </div>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -87,6 +87,10 @@ body {
   --cln: var(--attn-line);
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 /* ── page + app bar ─────────────────────────────────────────────────────── */
 .page {
   max-width: 720px;
@@ -301,32 +305,35 @@ body {
   margin-top: 12px;
   line-height: 1.3;
 }
-button.stat {
-  appearance: none;
-  text-align: left;
-  width: 100%;
-  font: inherit;
+a.stat {
+  display: block;
+  text-decoration: none;
+  color: inherit;
   cursor: pointer;
   transition:
     transform 0.12s,
     box-shadow 0.12s;
 }
-button.stat:not(:disabled):hover {
+a.stat[href]:hover {
   transform: translateY(-1px);
   box-shadow:
     0 1px 2px rgba(35, 32, 27, 0.04),
     0 16px 32px -18px rgba(35, 32, 27, 0.4);
 }
-button.stat:focus-visible {
+a.stat:focus-visible {
   outline: 2px solid var(--c);
   outline-offset: 2px;
 }
-button.stat:disabled {
+a.stat:not([href]) {
   opacity: 0.5;
   cursor: default;
 }
 
 /* ── section cards ──────────────────────────────────────────────────────── */
+.sec,
+aside.col-side {
+  scroll-margin-top: 56px;
+}
 .sec {
   background: var(--card);
   border: 1px solid var(--line);


### PR DESCRIPTION
Closes #64.

## Summary

- `SummaryBoxes` summary cards changed from `<button onClick={getElementById}>` to `<a href="#section-id">` — no JS, pure HTML semantics
- `href` is omitted (not empty string) when count is 0; `aria-disabled="true"` signals the inactive state to assistive technology
- CSS `button.stat` selectors rewritten to `a.stat`; disabled state uses `a.stat:not([href])` instead of `:disabled`
- `scroll-behavior: smooth` added to `html` element
- `scroll-margin-top: 56px` added to `.sec` and `aside.col-side` to clear the sticky TopBar

No `document.getElementById` calls remain in `ReportSections.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)