### PR TITLE
Add demo mode with dummy data (#75)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ The key is passed through the Next.js API route to Anthropic and is not stored s
 
 Get a key at [console.anthropic.com](https://console.anthropic.com/).
 
+## Caveats
+
+Development has been tested with a limited set of annual statements. Different issuers may not be processed correctly
+and result in false flags.
+
 ## Running locally
 
 ```bash

--- a/app/Icon.tsx
+++ b/app/Icon.tsx
@@ -16,7 +16,8 @@ export type IconName =
   | "plus"
   | "message"
   | "refresh"
-  | "chevron";
+  | "chevron"
+  | "github";
 
 const ICONS: Record<IconName, string[]> = {
   check: ["M20 6 9 17l-5-5"],
@@ -59,6 +60,10 @@ const ICONS: Record<IconName, string[]> = {
     "M3 21v-5h5",
   ],
   chevron: ["m6 9 6 6 6-6"],
+  github: [
+    "M15 22v-4a4.8 4.8 0 0 0-1-3.5c3 0 6-2 6-5.5.08-1.25-.27-2.48-1-3.5.28-1.15.28-2.35 0-3.5 0 0-1 0-3 1.5-2.64-.5-5.36-.5-8 0C6 2 5 2 5 2c-.3 1.15-.3 2.35 0 3.5A5.403 5.403 0 0 0 4 9c0 3.5 3 5.5 6 5.5-.39.49-.68 1.05-.85 1.65-.17.6-.22 1.23-.15 1.85v4",
+    "M9 18c-4.51 2-5-2-7-2",
+  ],
 };
 
 export function Icon({

--- a/app/components/AttentionPointCard.tsx
+++ b/app/components/AttentionPointCard.tsx
@@ -83,7 +83,7 @@ export function AttentionPointCard({
         <button className="gbtn" onClick={() => setOpen((v) => !v)}>
           <Icon name="message" size={14} /> {toggleLabel}
         </button>
-        {history.length === 0 && (
+        {history.length === 0 && initialMessages.length === 0 && (
           <button className="gbtn" onClick={handleMoreDetail} disabled={loading}>
             {loading ? "Bezig…" : "Meer uitleg"}
           </button>

--- a/app/components/AttentionPointCard.tsx
+++ b/app/components/AttentionPointCard.tsx
@@ -29,11 +29,13 @@ export function AttentionPointCard({
   taxYear,
   apiKey,
   initialMessages = [],
+  isDemo = false,
 }: {
   item: AttentionPoint;
   taxYear: number;
   apiKey: string;
   initialMessages?: ChatMessage[];
+  isDemo?: boolean;
 }) {
   const [open, setOpen] = useState(initialMessages.length > 0);
   const [question, setQuestion] = useState("");
@@ -83,7 +85,7 @@ export function AttentionPointCard({
         <button className="gbtn" onClick={() => setOpen((v) => !v)}>
           <Icon name="message" size={14} /> {toggleLabel}
         </button>
-        {history.length === 0 && initialMessages.length === 0 && (
+        {history.length === 0 && !isDemo && (
           <button className="gbtn" onClick={handleMoreDetail} disabled={loading}>
             {loading ? "Bezig…" : "Meer uitleg"}
           </button>

--- a/app/components/AttentionPointCard.tsx
+++ b/app/components/AttentionPointCard.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
 import { Icon } from "@/app/Icon";
-import type { AttentionPoint } from "@/lib/types";
+import type { AttentionPoint, ChatMessage } from "@/lib/types";
 import { useChatQuestion } from "@/app/hooks/useChatQuestion";
 
 const markdownComponents = {
@@ -28,15 +28,22 @@ export function AttentionPointCard({
   item,
   taxYear,
   apiKey,
+  initialMessages = [],
 }: {
   item: AttentionPoint;
   taxYear: number;
   apiKey: string;
+  initialMessages?: ChatMessage[];
 }) {
-  const [open, setOpen] = useState(false);
+  const [open, setOpen] = useState(initialMessages.length > 0);
   const [question, setQuestion] = useState("");
   const [resolved, setResolved] = useState(false);
-  const { history, loading, error, sendQuestion } = useChatQuestion(item, taxYear, apiKey);
+  const { history, loading, error, sendQuestion } = useChatQuestion(
+    item,
+    taxYear,
+    apiKey,
+    initialMessages
+  );
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/app/components/AttentionPointCard.tsx
+++ b/app/components/AttentionPointCard.tsx
@@ -4,7 +4,8 @@ import { useState } from "react";
 import ReactMarkdown from "react-markdown";
 import rehypeSanitize from "rehype-sanitize";
 import { Icon } from "@/app/Icon";
-import type { AttentionPoint, ChatMessage } from "@/lib/types";
+import type { AttentionPoint } from "@/lib/types";
+import { useDemo } from "@/app/contexts/DemoContext";
 import { useChatQuestion } from "@/app/hooks/useChatQuestion";
 
 const markdownComponents = {
@@ -28,15 +29,13 @@ export function AttentionPointCard({
   item,
   taxYear,
   apiKey,
-  initialMessages = [],
-  isDemo = false,
 }: {
   item: AttentionPoint;
   taxYear: number;
   apiKey: string;
-  initialMessages?: ChatMessage[];
-  isDemo?: boolean;
 }) {
+  const isDemo = useDemo();
+  const initialMessages = item.initialMessages ?? [];
   const [open, setOpen] = useState(initialMessages.length > 0);
   const [question, setQuestion] = useState("");
   const [resolved, setResolved] = useState(false);

--- a/app/components/ReportSections.tsx
+++ b/app/components/ReportSections.tsx
@@ -1,6 +1,3 @@
-"use client";
-
-import { useState } from "react";
 import { Icon } from "@/app/Icon";
 import type {
   AnalysisReport,
@@ -88,16 +85,10 @@ function Section({
   children: React.ReactNode;
   id?: string;
 }) {
-  const [open, setOpen] = useState(true);
   if (count === 0) return null;
   return (
     <div id={id} className={`sec tone-${tone}`}>
-      <button
-        type="button"
-        aria-expanded={open}
-        className={`sechead${open ? "" : " collapsed"}`}
-        onClick={() => setOpen((v) => !v)}
-      >
+      <div className="sechead">
         <span className="chip">
           <Icon name={icon} size={16} />
         </span>
@@ -105,17 +96,9 @@ function Section({
           <div className="t">{title}</div>
           {note && <div className="note">{note}</div>}
         </div>
-        <div className="sechead-actions">
-          <span className="pill num">{count}</span>
-          <Icon
-            name="chevron"
-            size={16}
-            className="sechead-chevron"
-            style={{ transform: open ? "rotate(0deg)" : "rotate(-90deg)" }}
-          />
-        </div>
-      </button>
-      {open && children}
+        <span className="pill num">{count}</span>
+      </div>
+      {children}
     </div>
   );
 }

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -1,16 +1,18 @@
+"use client";
+
 import { Icon } from "@/app/Icon";
+import { useDemo } from "@/app/contexts/DemoContext";
 
 export function TopBar({
   taxYear,
   onReset,
-  isDemo,
   onDemo,
 }: {
   taxYear?: number;
   onReset?: () => void;
-  isDemo?: boolean;
   onDemo?: () => void;
 }) {
+  const isDemo = useDemo();
   return (
     <header className="topbar">
       <div className="topbar-inner">

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -14,42 +14,49 @@ export function TopBar({
   return (
     <header className="topbar">
       <div className="topbar-inner">
-        <div className="brand">
-          <div className="logo">
-            <Icon name="shield" size={19} />
-          </div>
-          <div>
-            {onReset ? (
-              <button className="brand-link" onClick={onReset}>
-                <span className="wm">Aangifte Checker</span>
-                {isDemo && <span className="demo-chip">Demo</span>}
-              </button>
-            ) : (
-              <div className="wm">Aangifte Checker</div>
-            )}
-            {taxYear && <div className="sub">Belastingjaar {taxYear}</div>}
+        <div className="topbar-left">
+          <div className="brand">
+            <div className="logo">
+              <Icon name="shield" size={19} />
+            </div>
+            <div>
+              {onReset ? (
+                <button className="brand-link" onClick={onReset}>
+                  <span className="wm">Aangifte Checker</span>
+                  {isDemo && <span className="demo-chip">Demo</span>}
+                </button>
+              ) : (
+                <div className="wm">Aangifte Checker</div>
+              )}
+              {taxYear && <div className="sub">Belastingjaar {taxYear}</div>}
+            </div>
           </div>
         </div>
-        {onDemo && (
-          <button className="topbar-demo" type="button" onClick={onDemo}>
-            Probeer de demo
-          </button>
-        )}
-        <div className="spacer" />
-        <a
-          href="https://github.com/rpbaptist/belastingaangifte-check"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="ghostbtn"
-          aria-label="Bekijk broncode op GitHub"
-        >
-          <Icon name="github" size={15} /> GitHub
-        </a>
-        {onReset && !isDemo && (
-          <button className="ghostbtn" onClick={onReset}>
-            <Icon name="refresh" size={15} /> Opnieuw analyseren
-          </button>
-        )}
+
+        <div className="topbar-center">
+          {onDemo && (
+            <button className="topbar-demo" type="button" onClick={onDemo}>
+              Probeer de demo
+            </button>
+          )}
+        </div>
+
+        <div className="topbar-right">
+          <a
+            href="https://github.com/rpbaptist/belastingaangifte-check"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ghostbtn"
+            aria-label="Bekijk broncode op GitHub"
+          >
+            <Icon name="github" size={15} /> GitHub
+          </a>
+          {onReset && !isDemo && (
+            <button className="ghostbtn" onClick={onReset}>
+              <Icon name="refresh" size={15} /> Opnieuw analyseren
+            </button>
+          )}
+        </div>
       </div>
     </header>
   );

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -14,6 +14,15 @@ export function TopBar({ taxYear, onReset }: { taxYear?: number; onReset?: () =>
           </div>
         </div>
         <div className="spacer" />
+        <a
+          href="https://github.com/rpbaptist/belastingaangifte-check"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="ghostbtn"
+          aria-label="Bekijk broncode op GitHub"
+        >
+          <Icon name="github" size={15} /> GitHub
+        </a>
         {onReset && (
           <button className="ghostbtn" onClick={onReset}>
             <Icon name="refresh" size={15} /> Opnieuw analyseren

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -4,10 +4,12 @@ export function TopBar({
   taxYear,
   onReset,
   isDemo,
+  onDemo,
 }: {
   taxYear?: number;
   onReset?: () => void;
   isDemo?: boolean;
+  onDemo?: () => void;
 }) {
   return (
     <header className="topbar">
@@ -28,6 +30,11 @@ export function TopBar({
             {taxYear && <div className="sub">Belastingjaar {taxYear}</div>}
           </div>
         </div>
+        {onDemo && (
+          <button className="topbar-demo" type="button" onClick={onDemo}>
+            Probeer de demo
+          </button>
+        )}
         <div className="spacer" />
         <a
           href="https://github.com/rpbaptist/belastingaangifte-check"

--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -1,6 +1,14 @@
 import { Icon } from "@/app/Icon";
 
-export function TopBar({ taxYear, onReset }: { taxYear?: number; onReset?: () => void }) {
+export function TopBar({
+  taxYear,
+  onReset,
+  isDemo,
+}: {
+  taxYear?: number;
+  onReset?: () => void;
+  isDemo?: boolean;
+}) {
   return (
     <header className="topbar">
       <div className="topbar-inner">
@@ -9,7 +17,14 @@ export function TopBar({ taxYear, onReset }: { taxYear?: number; onReset?: () =>
             <Icon name="shield" size={19} />
           </div>
           <div>
-            <div className="wm">Aangifte Checker</div>
+            {onReset ? (
+              <button className="brand-link" onClick={onReset}>
+                <span className="wm">Aangifte Checker</span>
+                {isDemo && <span className="demo-chip">Demo</span>}
+              </button>
+            ) : (
+              <div className="wm">Aangifte Checker</div>
+            )}
             {taxYear && <div className="sub">Belastingjaar {taxYear}</div>}
           </div>
         </div>
@@ -23,7 +38,7 @@ export function TopBar({ taxYear, onReset }: { taxYear?: number; onReset?: () =>
         >
           <Icon name="github" size={15} /> GitHub
         </a>
-        {onReset && (
+        {onReset && !isDemo && (
           <button className="ghostbtn" onClick={onReset}>
             <Icon name="refresh" size={15} /> Opnieuw analyseren
           </button>

--- a/app/contexts/DemoContext.tsx
+++ b/app/contexts/DemoContext.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+const DemoContext = createContext(false);
+
+export const DemoProvider = DemoContext.Provider;
+
+export function useDemo() {
+  return useContext(DemoContext);
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -147,6 +147,43 @@ html {
   color: var(--ink-3);
   margin-top: 1px;
 }
+.brand-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  color: inherit;
+}
+.brand-link:hover .wm {
+  color: var(--bronze);
+}
+.demo-chip {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bronze);
+  background: color-mix(in oklab, var(--bronze) 12%, transparent);
+  border: 1px solid color-mix(in oklab, var(--bronze) 30%, transparent);
+  border-radius: 4px;
+  padding: 2px 6px;
+  line-height: 1.4;
+}
+.demo-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 2px;
+}
+.demo-hint {
+  font-size: 12px;
+  color: var(--ink-3);
+  margin: 0;
+}
 
 .ghostbtn {
   display: inline-flex;

--- a/app/globals.css
+++ b/app/globals.css
@@ -108,16 +108,27 @@ html {
   border-bottom: 1px solid var(--line);
 }
 .topbar-inner {
-  max-width: 720px;
+  max-width: 1200px;
   margin: 0 auto;
   padding: 12px 26px;
-  display: flex;
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
   align-items: center;
   gap: 14px;
-  position: relative;
 }
-.topbar .spacer {
-  flex: 1;
+.topbar-left {
+  display: flex;
+  align-items: center;
+}
+.topbar-center {
+  display: flex;
+  justify-content: center;
+}
+.topbar-right {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 14px;
 }
 
 .brand {
@@ -175,9 +186,6 @@ html {
   line-height: 1.4;
 }
 .topbar-demo {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
   display: inline-flex;
   align-items: center;
   font-family: inherit;

--- a/app/globals.css
+++ b/app/globals.css
@@ -114,6 +114,7 @@ html {
   display: flex;
   align-items: center;
   gap: 14px;
+  position: relative;
 }
 .topbar .spacer {
   flex: 1;
@@ -173,16 +174,29 @@ html {
   padding: 2px 6px;
   line-height: 1.4;
 }
-.demo-row {
-  display: flex;
+.topbar-demo {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: inline-flex;
   align-items: center;
-  gap: 12px;
-  margin-top: 2px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+  color: var(--bronze);
+  background: color-mix(in oklab, var(--bronze) 10%, transparent);
+  border: 1px solid color-mix(in oklab, var(--bronze) 35%, transparent);
+  border-radius: 999px;
+  padding: 6px 16px;
+  cursor: pointer;
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
-.demo-hint {
-  font-size: 12px;
-  color: var(--ink-3);
-  margin: 0;
+.topbar-demo:hover {
+  background: color-mix(in oklab, var(--bronze) 18%, transparent);
+  border-color: var(--bronze);
 }
 
 .ghostbtn {

--- a/app/globals.css
+++ b/app/globals.css
@@ -410,27 +410,6 @@ aside.col-side {
 .irow .label-col {
   min-width: 0;
 }
-button.sechead {
-  appearance: none;
-  text-align: left;
-  width: 100%;
-  font: inherit;
-  cursor: pointer;
-}
-button.sechead:focus-visible {
-  outline: 2px solid var(--c);
-  outline-offset: -2px;
-}
-.sechead-actions {
-  margin-left: auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-.sechead-chevron {
-  color: var(--c);
-  transition: transform 0.18s;
-}
 
 /* ── attention ──────────────────────────────────────────────────────────── */
 .ahead + .stack {

--- a/app/hooks/useAnalysis.ts
+++ b/app/hooks/useAnalysis.ts
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect } from "react";
 import type { AnalysisReport, ExtractedData } from "@/lib/types";
 import { AnalyseResponseSchema, ApiErrorSchema } from "@/lib/schemas";
 import { authHeaders } from "@/lib/apiUtils";
+import { DEMO_REPORT, DEMO_EXTRACTED_DATA } from "@/lib/demo-data";
 
 export function useAnalysis(apiKey: string) {
   const [loading, setLoading] = useState(false);
@@ -12,6 +13,7 @@ export function useAnalysis(apiKey: string) {
   const [error, setError] = useState<string | null>(null);
   const [incrementalLoading, setIncrementalLoading] = useState(false);
   const [incrementalError, setIncrementalError] = useState<string | null>(null);
+  const [isDemo, setIsDemo] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -85,11 +87,20 @@ export function useAnalysis(apiKey: string) {
     }
   }
 
+  function loadDemo() {
+    abortRef.current?.abort();
+    setReport(DEMO_REPORT);
+    setExtractedData(DEMO_EXTRACTED_DATA);
+    setError(null);
+    setIsDemo(true);
+  }
+
   function reset() {
     abortRef.current?.abort();
     setReport(null);
     setExtractedData(null);
     setError(null);
+    setIsDemo(false);
   }
 
   return {
@@ -99,8 +110,10 @@ export function useAnalysis(apiKey: string) {
     error,
     incrementalLoading,
     incrementalError,
+    isDemo,
     analyze,
     analyzeIncremental,
+    loadDemo,
     reset,
   };
 }

--- a/app/hooks/useAnalysis.ts
+++ b/app/hooks/useAnalysis.ts
@@ -4,7 +4,6 @@ import { useState, useRef, useEffect } from "react";
 import type { AnalysisReport, ExtractedData } from "@/lib/types";
 import { AnalyseResponseSchema, ApiErrorSchema } from "@/lib/schemas";
 import { authHeaders } from "@/lib/apiUtils";
-import { DEMO_REPORT, DEMO_EXTRACTED_DATA } from "@/lib/demo-data";
 
 export function useAnalysis(apiKey: string) {
   const [loading, setLoading] = useState(false);
@@ -13,7 +12,6 @@ export function useAnalysis(apiKey: string) {
   const [error, setError] = useState<string | null>(null);
   const [incrementalLoading, setIncrementalLoading] = useState(false);
   const [incrementalError, setIncrementalError] = useState<string | null>(null);
-  const [isDemo, setIsDemo] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
 
   useEffect(() => () => abortRef.current?.abort(), []);
@@ -87,20 +85,11 @@ export function useAnalysis(apiKey: string) {
     }
   }
 
-  function loadDemo() {
-    abortRef.current?.abort();
-    setReport(DEMO_REPORT);
-    setExtractedData(DEMO_EXTRACTED_DATA);
-    setError(null);
-    setIsDemo(true);
-  }
-
   function reset() {
     abortRef.current?.abort();
     setReport(null);
     setExtractedData(null);
     setError(null);
-    setIsDemo(false);
   }
 
   return {
@@ -110,10 +99,8 @@ export function useAnalysis(apiKey: string) {
     error,
     incrementalLoading,
     incrementalError,
-    isDemo,
     analyze,
     analyzeIncremental,
-    loadDemo,
     reset,
   };
 }

--- a/app/hooks/useChatQuestion.ts
+++ b/app/hooks/useChatQuestion.ts
@@ -5,8 +5,13 @@ import type { AttentionPoint, ChatMessage, QuestionRequest } from "@/lib/types";
 import { QuestionResponseSchema, ApiErrorSchema } from "@/lib/schemas";
 import { authHeaders } from "@/lib/apiUtils";
 
-export function useChatQuestion(item: AttentionPoint, taxYear: number, apiKey: string) {
-  const [history, setHistory] = useState<ChatMessage[]>([]);
+export function useChatQuestion(
+  item: AttentionPoint,
+  taxYear: number,
+  apiKey: string,
+  initialMessages: ChatMessage[] = []
+) {
+  const [history, setHistory] = useState<ChatMessage[]>(initialMessages);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/app/hooks/useDemoMode.ts
+++ b/app/hooks/useDemoMode.ts
@@ -1,0 +1,16 @@
+"use client";
+
+import { useState } from "react";
+import { DEMO_REPORT, DEMO_EXTRACTED_DATA } from "@/lib/demo-data";
+
+export function useDemoMode() {
+  const [active, setActive] = useState(false);
+
+  return {
+    active,
+    report: active ? DEMO_REPORT : null,
+    extractedData: active ? DEMO_EXTRACTED_DATA : null,
+    load: () => setActive(true),
+    reset: () => setActive(false),
+  };
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -14,6 +14,7 @@ import {
   NotFilledInSection,
 } from "./components/ReportSections";
 import { useAnalysis } from "./hooks/useAnalysis";
+import { useDemoMode } from "./hooks/useDemoMode";
 import { useApiKeyStorage } from "./hooks/useApiKeyStorage";
 import { IncrementalCard } from "./components/IncrementalCard";
 import { AnalysisProgress } from "./components/AnalysisProgress";
@@ -28,9 +29,21 @@ export default function Home() {
   const isEnvKey = !!process.env.NEXT_PUBLIC_ANTHROPIC_API_KEY;
   const [apiKey, setApiKey] = useApiKeyStorage(isEnvKey);
 
+  const demo = useDemoMode();
   const analysis = useAnalysis(apiKey);
-  const { loading, report, extractedData, error, incrementalLoading, incrementalError, isDemo } =
-    analysis;
+  const { loading, error, incrementalLoading, incrementalError } = analysis;
+  const report = demo.active ? demo.report : analysis.report;
+  const extractedData = demo.active ? demo.extractedData : analysis.extractedData;
+
+  function handleLoadDemo() {
+    analysis.reset();
+    demo.load();
+  }
+
+  function handleReset() {
+    analysis.reset();
+    demo.reset();
+  }
 
   const canSubmit = aangifte !== null && jaaropgaves.length > 0 && apiKey.length > 0 && !loading;
 
@@ -45,7 +58,7 @@ export default function Home() {
   if (!report) {
     return (
       <>
-        <TopBar onDemo={analysis.loadDemo} />
+        <TopBar onDemo={handleLoadDemo} />
         <main className="page-upload">
           <div className="upload-card">
             {/* LEFT: hero */}
@@ -107,16 +120,16 @@ export default function Home() {
   }
 
   /* ── Results view ── */
-  const statementCount = isDemo
+  const statementCount = demo.active
     ? 4
     : (extractedData?.annualStatements.length ?? jaaropgaves.length);
   const hasAttn = report.attentionPoints.length > 0;
 
   return (
-    <DemoProvider value={isDemo}>
-      <TopBar taxYear={isDemo ? undefined : report.taxYear} onReset={analysis.reset} />
+    <DemoProvider value={demo.active}>
+      <TopBar taxYear={demo.active ? undefined : report.taxYear} onReset={handleReset} />
       <main className="page">
-        {!isDemo && (
+        {!demo.active && (
           <div className="files">
             <div className="grp">
               <span className="lab">Aangifte</span>
@@ -132,7 +145,7 @@ export default function Home() {
                 </span>
               ))}
             </div>
-            <button className="edit" onClick={analysis.reset}>
+            <button className="edit" onClick={handleReset}>
               <Icon name="plus" size={14} /> Wijzig
             </button>
           </div>
@@ -157,7 +170,7 @@ export default function Home() {
               <MissingStatementSection items={report.missingStatement} />
               <NotFilledInSection items={report.notFilledIn} />
             </div>
-            {!hasAttn && !isDemo && (
+            {!hasAttn && !demo.active && (
               <IncrementalCard
                 loading={incrementalLoading}
                 error={incrementalError}
@@ -187,7 +200,7 @@ export default function Home() {
                   ))}
                 </div>
               </div>
-              {!isDemo && (
+              {!demo.active && (
                 <IncrementalCard
                   loading={incrementalLoading}
                   error={incrementalError}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,7 +17,7 @@ import { useAnalysis } from "./hooks/useAnalysis";
 import { useApiKeyStorage } from "./hooks/useApiKeyStorage";
 import { IncrementalCard } from "./components/IncrementalCard";
 import { AnalysisProgress } from "./components/AnalysisProgress";
-import { DEMO_PREBAKED_MESSAGES } from "@/lib/demo-data";
+import { DemoProvider } from "./contexts/DemoContext";
 
 /* ─── Page ────────────────────────────────────────────────────────────────── */
 
@@ -113,12 +113,8 @@ export default function Home() {
   const hasAttn = report.attentionPoints.length > 0;
 
   return (
-    <>
-      <TopBar
-        taxYear={isDemo ? undefined : report.taxYear}
-        onReset={analysis.reset}
-        isDemo={isDemo}
-      />
+    <DemoProvider value={isDemo}>
+      <TopBar taxYear={isDemo ? undefined : report.taxYear} onReset={analysis.reset} />
       <main className="page">
         {!isDemo && (
           <div className="files">
@@ -187,8 +183,6 @@ export default function Home() {
                       item={p}
                       taxYear={report.taxYear}
                       apiKey={apiKey}
-                      initialMessages={isDemo ? (DEMO_PREBAKED_MESSAGES[p.title] ?? []) : []}
-                      isDemo={isDemo}
                     />
                   ))}
                 </div>
@@ -204,6 +198,6 @@ export default function Home() {
           )}
         </div>
       </main>
-    </>
+    </DemoProvider>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -114,7 +114,11 @@ export default function Home() {
 
   return (
     <>
-      <TopBar taxYear={report.taxYear} onReset={analysis.reset} isDemo={isDemo} />
+      <TopBar
+        taxYear={isDemo ? undefined : report.taxYear}
+        onReset={analysis.reset}
+        isDemo={isDemo}
+      />
       <main className="page">
         {!isDemo && (
           <div className="files">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -42,64 +42,65 @@ export default function Home() {
   /* ── Upload view ── */
   if (!report) {
     return (
-      <main className="page-upload">
-        <div className="upload-card">
-          {/* LEFT: hero */}
-          <div className="upload-hero">
-            <div className="brand">
-              <div className="logo">
-                <Icon name="shield" size={18} />
+      <>
+        <TopBar />
+        <main className="page-upload">
+          <div className="upload-card">
+            {/* LEFT: hero */}
+            <div className="upload-hero">
+              <h1 className="h1">Klopt je aangifte?</h1>
+              <p className="intro">
+                Upload je belastingaangifte en jaaropgaves. De bedragen worden vergeleken en je ziet
+                wat klopt, wat ontbreekt en waar je op moet letten.
+              </p>
+              <div className="notice">
+                <strong>Let op: demo, geen privacygarantie.</strong> De inhoud van je PDF&#39;s,
+                inclusief je BSN, IBANs en financiële gegevens, wordt verstuurd naar de{" "}
+                <a
+                  href="https://www.anthropic.com/privacy"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Anthropic API
+                </a>{" "}
+                voor verwerking. Anthropic bewaart API-data standaard tot 30 dagen. Gebruik dit
+                hulpmiddel uitsluitend voor eigen testdoeleinden en deel geen gegevens van anderen.
+                Controleer altijd zelf de resultaten of raadpleeg een financieel adviseur.
               </div>
-              <span className="wm">Aangifte Checker</span>
             </div>
-            <h1 className="h1">Klopt je aangifte?</h1>
-            <p className="intro">
-              Upload je belastingaangifte en jaaropgaves. De bedragen worden vergeleken en je ziet
-              wat klopt, wat ontbreekt en waar je op moet letten.
-            </p>
-            <div className="notice">
-              <strong>Let op: demo, geen privacygarantie.</strong> De inhoud van je PDF&#39;s,
-              inclusief je BSN, IBANs en financiële gegevens, wordt verstuurd naar de{" "}
-              <a href="https://www.anthropic.com/privacy" target="_blank" rel="noopener noreferrer">
-                Anthropic API
-              </a>{" "}
-              voor verwerking. Anthropic bewaart API-data standaard tot 30 dagen. Gebruik dit
-              hulpmiddel uitsluitend voor eigen testdoeleinden en deel geen gegevens van anderen.
-              Controleer altijd zelf de resultaten of raadpleeg een financieel adviseur.
-            </div>
-          </div>
 
-          {/* RIGHT: form */}
-          <div className="upload-form">
-            <ApiKeyInput value={apiKey} onChange={setApiKey} isEnvKey={isEnvKey} />
-            <div className="dropzone-grid">
-              <DropZone
-                label="Belastingaangifte"
-                hint="Sleep je aangifte PDF hierheen, of klik om te bladeren"
-                accept="application/pdf"
-                multiple={false}
-                files={aangifte ? [aangifte] : []}
-                onFiles={(incoming) => setAangifte(incoming[0] ?? null)}
-              />
-              <DropZone
-                label="Jaaropgaves"
-                hint="Sleep één of meerdere PDF's hierheen of klik om te bladeren."
-                accept="application/pdf"
-                multiple
-                files={jaaropgaves}
-                onFiles={(incoming) => setJaaropgaves((prev) => [...prev, ...incoming])}
-              />
+            {/* RIGHT: form */}
+            <div className="upload-form">
+              <ApiKeyInput value={apiKey} onChange={setApiKey} isEnvKey={isEnvKey} />
+              <div className="dropzone-grid">
+                <DropZone
+                  label="Belastingaangifte"
+                  hint="Sleep je aangifte PDF hierheen, of klik om te bladeren"
+                  accept="application/pdf"
+                  multiple={false}
+                  files={aangifte ? [aangifte] : []}
+                  onFiles={(incoming) => setAangifte(incoming[0] ?? null)}
+                />
+                <DropZone
+                  label="Jaaropgaves"
+                  hint="Sleep één of meerdere PDF's hierheen of klik om te bladeren."
+                  accept="application/pdf"
+                  multiple
+                  files={jaaropgaves}
+                  onFiles={(incoming) => setJaaropgaves((prev) => [...prev, ...incoming])}
+                />
+              </div>
+              <form onSubmit={handleSubmit}>
+                <button className="btn" type="submit" disabled={!canSubmit}>
+                  {loading ? "Bezig met analyseren…" : "Analyseren"} <Icon name="arrow" size={16} />
+                </button>
+              </form>
+              <AnalysisProgress loading={loading} />
+              {error && <ErrorCard message={error} className="upload-error" />}
             </div>
-            <form onSubmit={handleSubmit}>
-              <button className="btn" type="submit" disabled={!canSubmit}>
-                {loading ? "Bezig met analyseren…" : "Analyseren"} <Icon name="arrow" size={16} />
-              </button>
-            </form>
-            <AnalysisProgress loading={loading} />
-            {error && <ErrorCard message={error} className="upload-error" />}
           </div>
-        </div>
-      </main>
+        </main>
+      </>
     );
   }
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -83,7 +83,7 @@ export default function Home() {
               />
               <DropZone
                 label="Jaaropgaves"
-                hint="Sleep één of meerdere PDF's hierheen — ING, Rabobank, DEGIRO, hypotheek …"
+                hint="Sleep één of meerdere PDF's hierheen of klik om te bladeren."
                 accept="application/pdf"
                 multiple
                 files={jaaropgaves}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -188,6 +188,7 @@ export default function Home() {
                       taxYear={report.taxYear}
                       apiKey={apiKey}
                       initialMessages={isDemo ? (DEMO_PREBAKED_MESSAGES[p.title] ?? []) : []}
+                      isDemo={isDemo}
                     />
                   ))}
                 </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -45,7 +45,7 @@ export default function Home() {
   if (!report) {
     return (
       <>
-        <TopBar />
+        <TopBar onDemo={analysis.loadDemo} />
         <main className="page-upload">
           <div className="upload-card">
             {/* LEFT: hero */}
@@ -97,12 +97,6 @@ export default function Home() {
                   {loading ? "Bezig met analyseren…" : "Analyseren"} <Icon name="arrow" size={16} />
                 </button>
               </form>
-              <div className="demo-row">
-                <button className="ghostbtn" type="button" onClick={analysis.loadDemo}>
-                  Probeer de demo
-                </button>
-                <span className="demo-hint">Geen bestanden of API-sleutel nodig.</span>
-              </div>
               <AnalysisProgress loading={loading} />
               {error && <ErrorCard message={error} className="upload-error" />}
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -17,6 +17,7 @@ import { useAnalysis } from "./hooks/useAnalysis";
 import { useApiKeyStorage } from "./hooks/useApiKeyStorage";
 import { IncrementalCard } from "./components/IncrementalCard";
 import { AnalysisProgress } from "./components/AnalysisProgress";
+import { DEMO_PREBAKED_MESSAGES } from "@/lib/demo-data";
 
 /* ─── Page ────────────────────────────────────────────────────────────────── */
 
@@ -28,7 +29,8 @@ export default function Home() {
   const [apiKey, setApiKey] = useApiKeyStorage(isEnvKey);
 
   const analysis = useAnalysis(apiKey);
-  const { loading, report, extractedData, error, incrementalLoading, incrementalError } = analysis;
+  const { loading, report, extractedData, error, incrementalLoading, incrementalError, isDemo } =
+    analysis;
 
   const canSubmit = aangifte !== null && jaaropgaves.length > 0 && apiKey.length > 0 && !loading;
 
@@ -95,6 +97,12 @@ export default function Home() {
                   {loading ? "Bezig met analyseren…" : "Analyseren"} <Icon name="arrow" size={16} />
                 </button>
               </form>
+              <div className="demo-row">
+                <button className="ghostbtn" type="button" onClick={analysis.loadDemo}>
+                  Probeer de demo
+                </button>
+                <span className="demo-hint">Geen bestanden of API-sleutel nodig.</span>
+              </div>
               <AnalysisProgress loading={loading} />
               {error && <ErrorCard message={error} className="upload-error" />}
             </div>
@@ -105,32 +113,36 @@ export default function Home() {
   }
 
   /* ── Results view ── */
-  const statementCount = extractedData?.annualStatements.length ?? jaaropgaves.length;
+  const statementCount = isDemo
+    ? 4
+    : (extractedData?.annualStatements.length ?? jaaropgaves.length);
   const hasAttn = report.attentionPoints.length > 0;
 
   return (
     <>
-      <TopBar taxYear={report.taxYear} onReset={analysis.reset} />
+      <TopBar taxYear={report.taxYear} onReset={analysis.reset} isDemo={isDemo} />
       <main className="page">
-        <div className="files">
-          <div className="grp">
-            <span className="lab">Aangifte</span>
-            <span className="fchip ok">
-              <Icon name="check" size={13} /> {aangifte?.name ?? "aangifte.pdf"}
-            </span>
-          </div>
-          <div className="grp">
-            <span className="lab">Jaaropgaves</span>
-            {jaaropgaves.map((f) => (
-              <span key={f.name} className="fchip">
-                <Icon name="file" size={13} /> {f.name}
+        {!isDemo && (
+          <div className="files">
+            <div className="grp">
+              <span className="lab">Aangifte</span>
+              <span className="fchip ok">
+                <Icon name="check" size={13} /> {aangifte?.name ?? "aangifte.pdf"}
               </span>
-            ))}
+            </div>
+            <div className="grp">
+              <span className="lab">Jaaropgaves</span>
+              {jaaropgaves.map((f) => (
+                <span key={f.name} className="fchip">
+                  <Icon name="file" size={13} /> {f.name}
+                </span>
+              ))}
+            </div>
+            <button className="edit" onClick={analysis.reset}>
+              <Icon name="plus" size={14} /> Wijzig
+            </button>
           </div>
-          <button className="edit" onClick={analysis.reset}>
-            <Icon name="plus" size={14} /> Wijzig
-          </button>
-        </div>
+        )}
 
         <div className="res-header">
           <div className="eyebrow">Resultaat</div>
@@ -151,7 +163,7 @@ export default function Home() {
               <MissingStatementSection items={report.missingStatement} />
               <NotFilledInSection items={report.notFilledIn} />
             </div>
-            {!hasAttn && (
+            {!hasAttn && !isDemo && (
               <IncrementalCard
                 loading={incrementalLoading}
                 error={incrementalError}
@@ -177,15 +189,18 @@ export default function Home() {
                       item={p}
                       taxYear={report.taxYear}
                       apiKey={apiKey}
+                      initialMessages={isDemo ? (DEMO_PREBAKED_MESSAGES[p.title] ?? []) : []}
                     />
                   ))}
                 </div>
               </div>
-              <IncrementalCard
-                loading={incrementalLoading}
-                error={incrementalError}
-                onSubmit={analysis.analyzeIncremental}
-              />
+              {!isDemo && (
+                <IncrementalCard
+                  loading={incrementalLoading}
+                  error={incrementalError}
+                  onSubmit={analysis.analyzeIncremental}
+                />
+              )}
             </aside>
           )}
         </div>

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1,4 +1,4 @@
-import type { AnalysisReport, ExtractedData, ChatMessage } from "@/lib/types";
+import type { AnalysisReport, ExtractedData } from "@/lib/types";
 
 export const DEMO_REPORT: AnalysisReport = {
   taxYear: 2024,
@@ -69,6 +69,17 @@ export const DEMO_REPORT: AnalysisReport = {
         "ASN Bank heeft een spaartegoed van € 4.200 gerapporteerd dat niet in de aangifte staat. Box 3 vereist opgave van alle saldi op de peildatum 1 januari 2024. Voeg dit bedrag toe aan je aangifte.",
       institution: "ASN Bank",
       accountNumber: "NL11ASNB0987654321",
+      initialMessages: [
+        {
+          role: "user",
+          content: "Wat zijn de gevolgen als ik dit vergeten ben op te geven?",
+        },
+        {
+          role: "assistant",
+          content:
+            "Als je het spaartegoed van € 4.200 niet hebt opgegeven in box 3, kan de Belastingdienst dit later corrigeren via een navorderingsaanslag. Daarvoor geldt een termijn van vijf jaar.\n\n**Praktisch advies:**\n- Dien een verbeterde aangifte in via Mijn Belastingdienst. Dit kan tot vijf jaar na het belastingjaar.\n- Het belastingeffect is beperkt: box 3 wordt belast op basis van een forfaitair rendement. Voor € 4.200 extra vermogen is de extra belasting doorgaans slechts een tientje per jaar.\n- Als je totale vermogen onder het heffingsvrije vermogen blijft (€ 57.000 voor alleenstaanden in 2024), is er helemaal geen extra belasting verschuldigd.",
+        },
+      ],
     },
   ],
   extractionErrors: [],
@@ -77,18 +88,4 @@ export const DEMO_REPORT: AnalysisReport = {
 export const DEMO_EXTRACTED_DATA: ExtractedData = {
   taxReturn: { taxYear: 2024, entries: [] },
   annualStatements: [],
-};
-
-export const DEMO_PREBAKED_MESSAGES: Record<string, ChatMessage[]> = {
-  "Spaartegoed niet opgegeven": [
-    {
-      role: "user",
-      content: "Wat zijn de gevolgen als ik dit vergeten ben op te geven?",
-    },
-    {
-      role: "assistant",
-      content:
-        "Als je het spaartegoed van € 4.200 niet hebt opgegeven in box 3, kan de Belastingdienst dit later corrigeren via een navorderingsaanslag. Daarvoor geldt een termijn van vijf jaar.\n\n**Praktisch advies:**\n- Dien een verbeterde aangifte in via Mijn Belastingdienst. Dit kan tot vijf jaar na het belastingjaar.\n- Het belastingeffect is beperkt: box 3 wordt belast op basis van een forfaitair rendement. Voor € 4.200 extra vermogen is de extra belasting doorgaans slechts een tientje per jaar.\n- Als je totale vermogen onder het heffingsvrije vermogen blijft (€ 57.000 voor alleenstaanden in 2024), is er helemaal geen extra belasting verschuldigd.",
-    },
-  ],
 };

--- a/lib/demo-data.ts
+++ b/lib/demo-data.ts
@@ -1,0 +1,94 @@
+import type { AnalysisReport, ExtractedData, ChatMessage } from "@/lib/types";
+
+export const DEMO_REPORT: AnalysisReport = {
+  taxYear: 2024,
+  covered: [
+    {
+      field: "Saldo bank- en spaarrekeningen",
+      accountNumber: "NL91INGB0001234567",
+      institution: "ING",
+      amountTaxReturn: 15432,
+      amountStatement: 15432,
+    },
+    {
+      field: "Saldo bank- en spaarrekeningen",
+      accountNumber: "NL89ABNA0123456789",
+      institution: "ABN AMRO",
+      amountTaxReturn: 28750,
+      amountStatement: 28750,
+    },
+    {
+      field: "Hypotheekrente",
+      accountNumber: "NL64RABO0456789012",
+      institution: "Rabobank",
+      amountTaxReturn: 8640,
+      amountStatement: 8640,
+    },
+    {
+      field: "Loon",
+      accountNumber: "123456789L01",
+      institution: "Werkgever Demo B.V.",
+      amountTaxReturn: 42500,
+      amountStatement: 42500,
+    },
+  ],
+  missingStatement: [
+    {
+      field: "Premies lijfrenten",
+      accountNumber: "LP2024-001",
+      amount: 2500,
+      box: "1",
+    },
+  ],
+  notFilledIn: [
+    {
+      accountNumber: "NL11ASNB0987654321",
+      institution: "ASN Bank",
+      description: "Spaartegoed",
+      amount: 4200,
+    },
+  ],
+  attentionPoints: [
+    {
+      title: "Aflossingsvrij hypotheekdeel",
+      explanation:
+        "Je hypotheek bij Rabobank heeft een aflossingsvrij deel. Voor hypotheken afgesloten na 1 januari 2013 geldt hypotheekrenteaftrek alleen als er daadwerkelijk wordt afgelost. Controleer of het aflossingsvrije deel onder het overgangsrecht valt.",
+      institution: "Rabobank",
+      accountNumber: "NL64RABO0456789012",
+    },
+    {
+      title: "Buitenlandse bronbelasting",
+      explanation:
+        "Bij DeGiro is € 87 buitenlandse bronbelasting ingehouden op buitenlands dividend. Dit bedrag kan via de aangifte worden verrekend of als kostenpost worden opgevoerd, afhankelijk van het verdragsland. Controleer of het correct is verwerkt in box 3.",
+      institution: "DeGiro",
+      accountNumber: "DG-9876543",
+    },
+    {
+      title: "Spaartegoed niet opgegeven",
+      explanation:
+        "ASN Bank heeft een spaartegoed van € 4.200 gerapporteerd dat niet in de aangifte staat. Box 3 vereist opgave van alle saldi op de peildatum 1 januari 2024. Voeg dit bedrag toe aan je aangifte.",
+      institution: "ASN Bank",
+      accountNumber: "NL11ASNB0987654321",
+    },
+  ],
+  extractionErrors: [],
+};
+
+export const DEMO_EXTRACTED_DATA: ExtractedData = {
+  taxReturn: { taxYear: 2024, entries: [] },
+  annualStatements: [],
+};
+
+export const DEMO_PREBAKED_MESSAGES: Record<string, ChatMessage[]> = {
+  "Spaartegoed niet opgegeven": [
+    {
+      role: "user",
+      content: "Wat zijn de gevolgen als ik dit vergeten ben op te geven?",
+    },
+    {
+      role: "assistant",
+      content:
+        "Als je het spaartegoed van € 4.200 niet hebt opgegeven in box 3, kan de Belastingdienst dit later corrigeren via een navorderingsaanslag. Daarvoor geldt een termijn van vijf jaar.\n\n**Praktisch advies:**\n- Dien een verbeterde aangifte in via Mijn Belastingdienst. Dit kan tot vijf jaar na het belastingjaar.\n- Het belastingeffect is beperkt: box 3 wordt belast op basis van een forfaitair rendement. Voor € 4.200 extra vermogen is de extra belasting doorgaans slechts een tientje per jaar.\n- Als je totale vermogen onder het heffingsvrije vermogen blijft (€ 57.000 voor alleenstaanden in 2024), is er helemaal geen extra belasting verschuldigd.",
+    },
+  ],
+};

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -93,6 +93,7 @@ export interface AttentionPoint {
   explanation: string;
   institution?: string;
   accountNumber?: string;
+  initialMessages?: ChatMessage[];
 }
 
 export interface ExtractionError {


### PR DESCRIPTION
## Summary

- Adds a **"Probeer de demo"** button centered in the header (upload view only) that loads a pre-baked report with no API key or file upload required
- All four report categories are represented in the dummy data (Gedekt, Jaaropgave ontbreekt, Niet ingevuld, Aandachtspunten)
- Third attention point ships with a pre-baked Q&A exchange so visitors see the full chat flow
- In demo mode: "Demo" chip in title bar, brand title resets to upload on click, "Opnieuw analyseren" hidden, incremental upload hidden, "Meer uitleg" hidden on all attention point cards, tax year subtitle suppressed

## Test plan

- [ ] Click "Probeer de demo" without API key or files → full report renders
- [ ] "Demo" chip visible in title bar; clicking "Aangifte Checker" returns to upload view
- [ ] "Opnieuw analyseren" button absent; incremental upload section absent
- [ ] "Spaartegoed niet opgegeven" card starts expanded with pre-baked Q&A
- [ ] "Meer uitleg" absent on all attention point cards in demo mode
- [ ] "Belastingjaar" subtitle absent in demo mode
- [ ] Normal analysis flow unaffected

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)