### PR TITLE
Guard useAnalysis loading state against stale aborted requests

### DIFF
--- a/app/hooks/useAnalysis.test.tsx
+++ b/app/hooks/useAnalysis.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { act, renderHook } from "@testing-library/react";
 import { useAnalysis } from "./useAnalysis";

--- a/app/hooks/useAnalysis.test.tsx
+++ b/app/hooks/useAnalysis.test.tsx
@@ -77,4 +77,33 @@ describe("useAnalysis", () => {
 
     expect(firstSignal.aborted).toBe(true);
   });
+
+  it("does not clobber loading state when a stale aborted request settles after a newer one has started", async () => {
+    let rejectFirst!: (reason: unknown) => void;
+    const firstFetch = new Promise<Response>((_, reject) => {
+      rejectFirst = reject;
+    });
+    const secondFetch = new Promise<Response>(() => {});
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => firstFetch)
+      .mockImplementationOnce(() => secondFetch);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { result } = renderHook(() => useAnalysis("test-key", "nl"));
+    const file = new File(["content"], "aangifte.pdf");
+
+    await act(async () => {
+      result.current.analyze(file, []);
+    });
+    expect(result.current.loading).toBe(true);
+
+    await act(async () => {
+      result.current.analyze(file, []);
+      rejectFirst(new DOMException("Aborted", "AbortError"));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.loading).toBe(true);
+  });
 });

--- a/app/hooks/useAnalysis.ts
+++ b/app/hooks/useAnalysis.ts
@@ -48,7 +48,7 @@ export function useAnalysis(apiKey: string, language: Language) {
       if (err instanceof DOMException && err.name === "AbortError") return;
       setError(err instanceof Error ? err.message : translate("clientUnknownError", language));
     } finally {
-      setLoading(false);
+      if (abortRef.current === controller) setLoading(false);
     }
   }
 
@@ -84,7 +84,7 @@ export function useAnalysis(apiKey: string, language: Language) {
         err instanceof Error ? err.message : translate("clientUnknownError", language)
       );
     } finally {
-      setIncrementalLoading(false);
+      if (abortRef.current === controller) setIncrementalLoading(false);
     }
   }
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,9 +3,10 @@ import path from "path";
 
 export default defineConfig({
   test: {
-    environment: "jsdom",
+    environment: "node",
     include: ["lib/**/*.test.ts", "app/**/*.test.tsx"],
     exclude: ["node_modules/**", ".claude/**"],
+    setupFiles: ["./vitest.setup.ts"],
   },
   resolve: {
     alias: {

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,4 @@
+import { afterEach } from "vitest";
+import { cleanup } from "@testing-library/react";
+
+afterEach(cleanup);


### PR DESCRIPTION
## Summary
Follow-up to #80, from code review findings surfaced after that PR merged:

- **Bug fix**: `analyze()`/`analyzeIncremental()`'s `finally` blocks unconditionally reset `loading`/`incrementalLoading` to `false`. When a stale (superseded) request's fetch settled with `AbortError` after a newer request had already started, its `finally` still ran and flipped the loading flag back to `false` while the newer request was still in flight — re-enabling the submit button and hiding the progress indicator mid-analysis. Fixed by gating the reset on `abortRef.current` still pointing at that request's own controller.
- **Test infra**: the previous PR set the vitest `environment` to `jsdom` globally, adding ~10s of setup cost to all 14 node-only `lib/**` tests and losing the safety net that library code doesn't depend on browser globals. Scoped jsdom to the hook test file via a per-file `// @vitest-environment jsdom` pragma instead.
- **Test infra**: `@testing-library/react`'s `afterEach(cleanup)` was never wired up, so future component/hook tests would leak mounted DOM instances across test files. Registered via `setupFiles`.

## Test plan
- [x] `npm test` — 186 tests pass (new regression test for the loading-state race)
- [x] `npm run lint`
- [x] `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)