### PR TITLE
Move inline route-handler logic into lib/

### DIFF
--- a/app/api/analyze/route.ts
+++ b/app/api/analyze/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { runExtractionSession } from "@/lib/extraction-session";
+import { formatSessionFailure, runExtractionSession } from "@/lib/extraction-session";
 import { analyzeDocuments } from "@/lib/analyzer";
 import { classifyError } from "@/lib/anthropic-error";
 import { fileToBase64 } from "@/lib/file-utils";
-import { translate, formatTaxReturnProcessingError, type Language } from "@/lib/translations";
+import { translate, type Language } from "@/lib/translations";
 
 // Allow up to 300s — parallel extraction + analysis across many PDFs
 export const maxDuration = 300;
@@ -46,12 +46,8 @@ export async function POST(request: NextRequest) {
     const session = await runExtractionSession(taxReturnBase64, statements, apiKey, language);
 
     if (!session.ok) {
-      return NextResponse.json(
-        {
-          error: formatTaxReturnProcessingError(taxReturnFile.name, session.message, language),
-        },
-        { status: 422 }
-      );
+      const { status, message } = formatSessionFailure(taxReturnFile.name, session, language);
+      return NextResponse.json({ error: message }, { status });
     }
 
     const reportBase = await analyzeDocuments(

--- a/app/api/question/route.ts
+++ b/app/api/question/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { classifyError } from "@/lib/anthropic-error";
 import type { QuestionRequest, QuestionResponse } from "@/lib/types";
-import { buildQuestionSystem } from "@/lib/prompts/question";
-import { createClient, QUESTION_MODEL } from "@/lib/llm";
+import { buildQuestionMessages, buildQuestionSystem } from "@/lib/prompts/question";
+import { createClient, extractResponseText, QUESTION_MODEL } from "@/lib/llm";
 import { translate, type Language } from "@/lib/translations";
-import type Anthropic from "@anthropic-ai/sdk";
 
 export const maxDuration = 60;
 
@@ -27,20 +26,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: translate("noQuestionReceived", language) }, { status: 400 });
   }
 
-  const contextHeading =
-    language === "en"
-      ? `Attention Point (tax year ${taxYear})`
-      : `Aandachtspunt (belastingjaar ${taxYear})`;
-  const questionHeading = language === "en" ? "Question" : "Vraag";
-  const context = `## ${contextHeading}\n\n${JSON.stringify(attentionPoint, null, 2)}`;
-
-  const messages: Anthropic.MessageParam[] = history.length
-    ? [
-        { role: "user", content: `${context}\n\n## ${questionHeading}\n\n${history[0].content}` },
-        ...history.slice(1).map((m) => ({ role: m.role, content: m.content })),
-        { role: "user", content: question },
-      ]
-    : [{ role: "user", content: `${context}\n\n## ${questionHeading}\n\n${question}` }];
+  const messages = buildQuestionMessages(question, attentionPoint, taxYear, history, language);
 
   try {
     const response = await client.messages.create({
@@ -52,12 +38,12 @@ export async function POST(request: NextRequest) {
       messages,
     });
 
-    const textBlock = response.content.find((b) => b.type === "text");
-    if (!textBlock || textBlock.type !== "text") {
+    const text = extractResponseText(response);
+    if (!text) {
       return NextResponse.json({ error: translate("noAnswerReceived", language) }, { status: 500 });
     }
 
-    const result: QuestionResponse = { answer: textBlock.text };
+    const result: QuestionResponse = { answer: text };
     return NextResponse.json(result);
   } catch (err) {
     const { status, message } = classifyError(err, language);

--- a/app/api/question/route.ts
+++ b/app/api/question/route.ts
@@ -39,7 +39,7 @@ export async function POST(request: NextRequest) {
     });
 
     const text = extractResponseText(response);
-    if (!text) {
+    if (text === undefined) {
       return NextResponse.json({ error: translate("noAnswerReceived", language) }, { status: 500 });
     }
 

--- a/lib/extraction-session.test.ts
+++ b/lib/extraction-session.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { formatSessionFailure } from "./extraction-session";
+
+describe("formatSessionFailure", () => {
+  it("maps a failed session to a 422 with a Dutch processing-error message", () => {
+    const result = formatSessionFailure(
+      "aangifte.pdf",
+      { ok: false, message: "kon niet lezen" },
+      "nl"
+    );
+    expect(result).toEqual({
+      status: 422,
+      message: 'Aangifte "aangifte.pdf" kon niet worden verwerkt: kon niet lezen',
+    });
+  });
+
+  it("maps a failed session to a 422 with an English processing-error message", () => {
+    const result = formatSessionFailure(
+      "return.pdf",
+      { ok: false, message: "could not read" },
+      "en"
+    );
+    expect(result).toEqual({
+      status: 422,
+      message: 'Tax return "return.pdf" could not be processed: could not read',
+    });
+  });
+});

--- a/lib/extraction-session.ts
+++ b/lib/extraction-session.ts
@@ -2,7 +2,7 @@ import { extractAnnualStatement, extractTaxReturn } from "./extractor";
 import type { AnnualStatementData, ExtractionError, TaxReturnData } from "./types";
 import { isUserFacingError } from "./anthropic-error";
 import { createClient } from "./llm";
-import { translate, type Language } from "./translations";
+import { formatTaxReturnProcessingError, translate, type Language } from "./translations";
 
 type StatementInput = { data: string; filename: string };
 
@@ -14,6 +14,17 @@ export type ExtractionSessionResult =
       errors: ExtractionError[];
     }
   | { ok: false; message: string };
+
+export function formatSessionFailure(
+  fileName: string,
+  result: Extract<ExtractionSessionResult, { ok: false }>,
+  language: Language
+): { status: number; message: string } {
+  return {
+    status: 422,
+    message: formatTaxReturnProcessingError(fileName, result.message, language),
+  };
+}
 
 export async function runExtractionSession(
   taxReturnPdf: string,

--- a/lib/llm.test.ts
+++ b/lib/llm.test.ts
@@ -27,4 +27,9 @@ describe("extractResponseText", () => {
     ] as unknown as Anthropic.Message["content"]);
     expect(extractResponseText(response)).toBeUndefined();
   });
+
+  it("returns an empty string rather than undefined for an empty text block", () => {
+    const response = makeResponse([{ type: "text", text: "", citations: null }]);
+    expect(extractResponseText(response)).toBe("");
+  });
 });

--- a/lib/llm.test.ts
+++ b/lib/llm.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import type Anthropic from "@anthropic-ai/sdk";
+import { extractResponseText } from "./llm";
+
+function makeResponse(content: Anthropic.Message["content"]): Anthropic.Message {
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-haiku-4-5-20251001",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 10, output_tokens: 10 },
+    content,
+  } as Anthropic.Message;
+}
+
+describe("extractResponseText", () => {
+  it("returns the text of the first text block", () => {
+    const response = makeResponse([{ type: "text", text: "Het antwoord is...", citations: null }]);
+    expect(extractResponseText(response)).toBe("Het antwoord is...");
+  });
+
+  it("returns undefined when the response has no text block", () => {
+    const response = makeResponse([
+      { type: "tool_use", id: "toolu_1", name: "lookup", input: {} },
+    ] as unknown as Anthropic.Message["content"]);
+    expect(extractResponseText(response)).toBeUndefined();
+  });
+});

--- a/lib/llm.ts
+++ b/lib/llm.ts
@@ -7,3 +7,8 @@ export const QUESTION_MODEL = "claude-haiku-4-5-20251001";
 export function createClient(apiKey?: string): Anthropic {
   return new Anthropic(apiKey ? { apiKey } : {});
 }
+
+export function extractResponseText(response: Anthropic.Message): string | undefined {
+  const block = response.content.find((b) => b.type === "text");
+  return block?.type === "text" ? block.text : undefined;
+}

--- a/lib/prompts/question.test.ts
+++ b/lib/prompts/question.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { buildQuestionMessages } from "./question";
+
+describe("buildQuestionMessages", () => {
+  it("builds a single user message with the context and question when there is no history", () => {
+    const messages = buildQuestionMessages(
+      "Moet ik dit opgeven?",
+      { title: "Hypotheekrente" },
+      2024,
+      [],
+      "nl"
+    );
+
+    expect(messages).toEqual([
+      {
+        role: "user",
+        content:
+          '## Aandachtspunt (belastingjaar 2024)\n\n{\n  "title": "Hypotheekrente"\n}\n\n## Vraag\n\nMoet ik dit opgeven?',
+      },
+    ]);
+  });
+
+  it("prepends the context to the first history entry and appends the new question", () => {
+    const history: Array<{ role: "user" | "assistant"; content: string }> = [
+      { role: "user", content: "Wat betekent dit?" },
+      { role: "assistant", content: "Dit betekent dat..." },
+    ];
+
+    const messages = buildQuestionMessages(
+      "En wat nu?",
+      { title: "Hypotheekrente" },
+      2024,
+      history,
+      "nl"
+    );
+
+    expect(messages).toEqual([
+      {
+        role: "user",
+        content:
+          '## Aandachtspunt (belastingjaar 2024)\n\n{\n  "title": "Hypotheekrente"\n}\n\n## Vraag\n\nWat betekent dit?',
+      },
+      { role: "assistant", content: "Dit betekent dat..." },
+      { role: "user", content: "En wat nu?" },
+    ]);
+  });
+
+  it("uses English headings when language is 'en'", () => {
+    const messages = buildQuestionMessages(
+      "Do I need to report this?",
+      { title: "x" },
+      2024,
+      [],
+      "en"
+    );
+
+    expect(messages[0].content).toContain("## Attention Point (tax year 2024)");
+    expect(messages[0].content).toContain("## Question");
+  });
+});

--- a/lib/prompts/question.test.ts
+++ b/lib/prompts/question.test.ts
@@ -5,7 +5,7 @@ describe("buildQuestionMessages", () => {
   it("builds a single user message with the context and question when there is no history", () => {
     const messages = buildQuestionMessages(
       "Moet ik dit opgeven?",
-      { title: "Hypotheekrente" },
+      { title: "Hypotheekrente", explanation: "Rente niet in aangifte" },
       2024,
       [],
       "nl"
@@ -15,7 +15,7 @@ describe("buildQuestionMessages", () => {
       {
         role: "user",
         content:
-          '## Aandachtspunt (belastingjaar 2024)\n\n{\n  "title": "Hypotheekrente"\n}\n\n## Vraag\n\nMoet ik dit opgeven?',
+          '## Aandachtspunt (belastingjaar 2024)\n\n{\n  "title": "Hypotheekrente",\n  "explanation": "Rente niet in aangifte"\n}\n\n## Vraag\n\nMoet ik dit opgeven?',
       },
     ]);
   });
@@ -28,7 +28,7 @@ describe("buildQuestionMessages", () => {
 
     const messages = buildQuestionMessages(
       "En wat nu?",
-      { title: "Hypotheekrente" },
+      { title: "Hypotheekrente", explanation: "Rente niet in aangifte" },
       2024,
       history,
       "nl"
@@ -38,7 +38,7 @@ describe("buildQuestionMessages", () => {
       {
         role: "user",
         content:
-          '## Aandachtspunt (belastingjaar 2024)\n\n{\n  "title": "Hypotheekrente"\n}\n\n## Vraag\n\nWat betekent dit?',
+          '## Aandachtspunt (belastingjaar 2024)\n\n{\n  "title": "Hypotheekrente",\n  "explanation": "Rente niet in aangifte"\n}\n\n## Vraag\n\nWat betekent dit?',
       },
       { role: "assistant", content: "Dit betekent dat..." },
       { role: "user", content: "En wat nu?" },
@@ -48,7 +48,7 @@ describe("buildQuestionMessages", () => {
   it("uses English headings when language is 'en'", () => {
     const messages = buildQuestionMessages(
       "Do I need to report this?",
-      { title: "x" },
+      { title: "x", explanation: "y" },
       2024,
       [],
       "en"

--- a/lib/prompts/question.ts
+++ b/lib/prompts/question.ts
@@ -1,4 +1,5 @@
 import type Anthropic from "@anthropic-ai/sdk";
+import type { AttentionPoint } from "../types";
 import type { Language } from "../translations";
 
 const QUESTION_SYSTEM_NL = `Je bent een Nederlandse belastingadviseur. Je beantwoordt vragen over aandachtspunten die zijn gevonden in een belastingaangifte-analyse.
@@ -25,7 +26,7 @@ export function buildQuestionSystem(language: Language = "nl"): string {
 
 export function buildQuestionMessages(
   question: string,
-  attentionPoint: unknown,
+  attentionPoint: AttentionPoint,
   taxYear: number,
   history: Array<{ role: "user" | "assistant"; content: string }>,
   language: Language

--- a/lib/prompts/question.ts
+++ b/lib/prompts/question.ts
@@ -1,3 +1,4 @@
+import type Anthropic from "@anthropic-ai/sdk";
 import type { Language } from "../translations";
 
 const QUESTION_SYSTEM_NL = `Je bent een Nederlandse belastingadviseur. Je beantwoordt vragen over aandachtspunten die zijn gevonden in een belastingaangifte-analyse.
@@ -20,4 +21,27 @@ Guidelines:
 
 export function buildQuestionSystem(language: Language = "nl"): string {
   return language === "en" ? QUESTION_SYSTEM_EN : QUESTION_SYSTEM_NL;
+}
+
+export function buildQuestionMessages(
+  question: string,
+  attentionPoint: unknown,
+  taxYear: number,
+  history: Array<{ role: "user" | "assistant"; content: string }>,
+  language: Language
+): Anthropic.MessageParam[] {
+  const contextHeading =
+    language === "en"
+      ? `Attention Point (tax year ${taxYear})`
+      : `Aandachtspunt (belastingjaar ${taxYear})`;
+  const questionHeading = language === "en" ? "Question" : "Vraag";
+  const context = `## ${contextHeading}\n\n${JSON.stringify(attentionPoint, null, 2)}`;
+
+  return history.length
+    ? [
+        { role: "user", content: `${context}\n\n## ${questionHeading}\n\n${history[0].content}` },
+        ...history.slice(1).map((m) => ({ role: m.role, content: m.content })),
+        { role: "user", content: question },
+      ]
+    : [{ role: "user", content: `${context}\n\n## ${questionHeading}\n\n${question}` }];
 }


### PR DESCRIPTION
Closes #81

## Summary
- Move the `session.ok === false → 422` response mapping in `app/api/analyze/route.ts` into `formatSessionFailure()` in `lib/extraction-session.ts`.
- Move the Anthropic `messages` array construction in `app/api/question/route.ts` into `buildQuestionMessages()` in `lib/prompts/question.ts`.
- Move the LLM response text-block extraction in `app/api/question/route.ts` into `extractResponseText()` in `lib/llm.ts`.

Route handlers now parse the request, delegate to `lib/*`, and map the result to a response — per AGENTS.md's code style rule. No behavior change: same status codes, same messages, same request/response shapes.

## Test plan
- [x] `npx vitest run` — 190 tests pass, including new unit tests for `formatSessionFailure`, `buildQuestionMessages`, `extractResponseText`
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npm run format` — clean