### PR TITLE
Dedupe text-block extraction across lib/llm, analyzer, extractor

### DIFF
--- a/lib/analyzer.ts
+++ b/lib/analyzer.ts
@@ -9,7 +9,7 @@ import { runRuleChecks } from "./rule-checks";
 import { LLMAnalysisResponseSchema } from "./schemas";
 import { buildAnalyzerPrompt, buildUserMessage } from "./prompts/analyzer";
 import { readAnalysisCache, writeAnalysisCache } from "./extraction-cache";
-import { ANALYSIS_MODEL, createClient } from "./llm";
+import { ANALYSIS_MODEL, createClient, extractResponseText } from "./llm";
 import { translate, formatAnalysisFailed, type Language } from "./translations";
 import { retrieveKennisbankContext, formatRetrievedContext } from "./rag/retrieval";
 import type Anthropic from "@anthropic-ai/sdk";
@@ -43,12 +43,12 @@ export function parseAnalysisResponse(
     throw new Error(translate("analysisAbortedTooMany", language));
   }
 
-  const textBlock = response.content.find((b) => b.type === "text");
-  if (!textBlock || textBlock.type !== "text") {
+  const text = extractResponseText(response);
+  if (text === undefined) {
     throw new Error(translate("noResponseDuringAnalysis", language));
   }
 
-  const raw = parseLlmJson(textBlock.text);
+  const raw = parseLlmJson(text);
   try {
     const { attentionPoints } = LLMAnalysisResponseSchema.parse(raw);
     return attentionPoints;

--- a/lib/extractor.test.ts
+++ b/lib/extractor.test.ts
@@ -1,6 +1,25 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import Anthropic from "@anthropic-ai/sdk";
 import { withRetry } from "./utils";
+import { extractAnnualStatement, extractTaxReturn } from "./extractor";
+
+function makeResponse(overrides: Partial<Anthropic.Message> = {}): Anthropic.Message {
+  return {
+    id: "msg_test",
+    type: "message",
+    role: "assistant",
+    model: "claude-haiku-4-5-20251001",
+    stop_reason: "end_turn",
+    stop_sequence: null,
+    usage: { input_tokens: 10, output_tokens: 10 },
+    content: [],
+    ...overrides,
+  } as Anthropic.Message;
+}
+
+function makeClient(response: Anthropic.Message): Anthropic {
+  return { messages: { create: vi.fn().mockResolvedValue(response) } } as unknown as Anthropic;
+}
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -101,5 +120,21 @@ describe("withRetry", () => {
     );
     expect(result.ok).toBe(false);
     expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("extractAnnualStatement / extractTaxReturn", () => {
+  it("throws a Dutch error when the annual statement response has no text block", async () => {
+    const client = makeClient(makeResponse());
+    await expect(extractAnnualStatement("pdf-base64", client)).rejects.toThrow(
+      "Geen reactie ontvangen bij verwerking van de jaaropgave"
+    );
+  });
+
+  it("throws an English error when the tax return response has no text block", async () => {
+    const client = makeClient(makeResponse());
+    await expect(extractTaxReturn("pdf-base64", client, "en")).rejects.toThrow(
+      "No response received while processing the tax return"
+    );
   });
 });

--- a/lib/extractor.ts
+++ b/lib/extractor.ts
@@ -6,7 +6,7 @@ import { parseLlmJson } from "./parse-llm-json";
 import { AnnualStatementSchema, TaxReturnSchema } from "./schemas";
 import { ANNUAL_STATEMENT_SYSTEM } from "./prompts/annual-statement";
 import { TAX_RETURN_SYSTEM } from "./prompts/tax-return";
-import { EXTRACTION_MODEL } from "./llm";
+import { EXTRACTION_MODEL, extractResponseText } from "./llm";
 import { withRetry } from "./utils";
 import { translate, formatExtractionFailed, type Language } from "./translations";
 
@@ -58,12 +58,12 @@ async function extract<T>(
   if (response.stop_reason === "max_tokens") {
     throw new Error(translate("extractionAbortedTooLarge", language));
   }
-  const textBlock = response.content.find((b) => b.type === "text");
-  if (!textBlock || textBlock.type !== "text") {
+  const text = extractResponseText(response);
+  if (text === undefined) {
     throw new Error(translate(opts.noResponseErrorKey, language));
   }
 
-  const raw = parseLlmJson(textBlock.text);
+  const raw = parseLlmJson(text);
   try {
     const result = opts.schema.parse(raw);
     writeCache(pdfBase64, result);


### PR DESCRIPTION
Closes #84

## Summary

- `lib/analyzer.ts`'s `parseAnalysisResponse` and `lib/extractor.ts`'s
  `extract` both reimplemented the same
  `response.content.find((b) => b.type === "text")` + type-narrowing
  pattern that `lib/llm.ts` already exposes as `extractResponseText()`
  (added for `app/api/question/route.ts`'s inline lookup).
- Both now call `extractResponseText()` directly and keep handling a
  missing text block their own way (different `translate()` key per
  call site), matching the existing pattern in `app/api/question/route.ts`
  — `extractResponseText` stays a raw, non-throwing extractor rather than
  gaining a throwing variant, since the three call sites' error messages
  never actually needed to be unified.
- Added regression coverage for `extractAnnualStatement`/
  `extractTaxReturn`'s no-text-block error path (previously untested).

## Test plan

- [x] `npm test` — 229 tests passing (2 new)
- [x] `npm run lint` / prettier — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm run check:fallow` — clean (only a pre-existing, out-of-scope tailwindcss finding, correctly excluded as inherited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)