### PR TITLE
Split oversized single paragraphs in the Kennisbank chunker

### DIFF
--- a/lib/rag/chunker.test.ts
+++ b/lib/rag/chunker.test.ts
@@ -80,4 +80,60 @@ describe("chunkText", () => {
 
     expect(chunks[1].text.startsWith("## Heading\n\n## Heading")).toBe(false);
   });
+
+  it("splits a single oversized paragraph with no blank line at the nearest whitespace", () => {
+    // One long paragraph, no blank line anywhere in it, well past maxChars.
+    const text = Array(200).fill("aftrekpost").join(" ");
+    const chunks = chunkText(
+      { url: "https://example.org/f", title: "Aaneengesloten alinea", text },
+      { maxChars: 1000 }
+    );
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0].text.length).toBeLessThanOrEqual(1000);
+    // The cut landed on whitespace, not mid-word: the first chunk is an exact
+    // prefix of the source text, and the very next character is whitespace.
+    expect(text.startsWith(chunks[0].text)).toBe(true);
+    expect(text[chunks[0].text.length]).toMatch(/\s/);
+  });
+
+  it("hard-cuts at maxChars when the oversized paragraph has no whitespace to split on", () => {
+    const text = "a".repeat(1500); // one unbroken token, no whitespace anywhere
+    const chunks = chunkText(
+      { url: "https://example.org/g", title: "Ononderbroken token", text },
+      { maxChars: 1000 }
+    );
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks[0].text).toBe("a".repeat(1000));
+  });
+
+  it("carries the heading into every chunk produced by splitting an oversized paragraph", () => {
+    const bigParagraph = Array(200).fill("aftrekpost").join(" ");
+    const chunks = chunkText(
+      {
+        url: "https://example.org/h",
+        title: "Aftrekposten",
+        text: `## Aftrekposten\n\n${bigParagraph}`,
+      },
+      { maxChars: 1000 }
+    );
+
+    expect(chunks.length).toBeGreaterThan(1);
+    for (const chunk of chunks) {
+      expect(chunk.text.startsWith("## Aftrekposten")).toBe(true);
+    }
+  });
+
+  it("carries overlap between chunks produced by splitting the same oversized paragraph", () => {
+    const bigParagraph = Array(200).fill("aftrekpost").join(" ");
+    const chunks = chunkText(
+      { url: "https://example.org/i", title: "Overlap binnen alinea", text: bigParagraph },
+      { maxChars: 1000, overlapChars: 120 }
+    );
+
+    expect(chunks.length).toBeGreaterThan(1);
+    const tailOfFirst = chunks[0].text.slice(-120);
+    expect(chunks[1].text.startsWith(tailOfFirst)).toBe(true);
+  });
 });

--- a/lib/rag/chunker.ts
+++ b/lib/rag/chunker.ts
@@ -15,6 +15,29 @@ const DEFAULT_OVERLAP_CHARS = 120;
 
 const HEADING_PATTERN = /^#{1,6}\s/;
 
+// Splits a paragraph longer than maxChars into fragments that fit within it, so
+// the main loop below never sees a single unit of text it can't bound. Cuts at
+// the whitespace nearest to maxChars (never past it) to avoid breaking a word;
+// falls back to a hard cut at exactly maxChars when no whitespace is in range —
+// sentence-aware splitting would need a dependency or a hand-rolled sentence
+// splitter, for a fallback path the current corpus never even exercises.
+function splitOversizedParagraph(paragraph: string, maxChars: number): string[] {
+  if (paragraph.length <= maxChars) return [paragraph];
+
+  const fragments: string[] = [];
+  let rest = paragraph;
+  while (rest.length > maxChars) {
+    const window = rest.slice(0, maxChars);
+    const whitespaceMatches = [...window.matchAll(/\s/g)];
+    const cut = whitespaceMatches.at(-1)?.index ?? maxChars;
+    fragments.push(rest.slice(0, cut).trim());
+    rest = rest.slice(cut).trim();
+  }
+  fragments.push(rest);
+
+  return fragments.filter((f) => f.length > 0);
+}
+
 // Starts a new chunk carrying its owning heading and a tail of overlap from the
 // previous chunk, so the new chunk reads standalone — but never duplicates text
 // that's identical to the heading (e.g. a heading immediately followed by an
@@ -43,7 +66,8 @@ export function chunkText(
   const paragraphs = doc.text
     .split(/\n\s*\n/)
     .map((p) => p.trim())
-    .filter((p) => p.length > 0);
+    .filter((p) => p.length > 0)
+    .flatMap((p) => splitOversizedParagraph(p, maxChars));
 
   const chunks: TextChunk[] = [];
   let current = "";


### PR DESCRIPTION
## Summary
- `chunkText()` only checked the `maxChars` overflow condition when the running chunk was already non-empty, so a single paragraph exceeding `maxChars` with no blank line to split on became one unbounded chunk.
- Fixes this by fragmenting any paragraph over `maxChars` — cutting at the nearest whitespace, hard-cutting only when none is in range — before the main accumulation loop runs, so fragments inherit existing heading-carry and overlap logic for free.
- Sentence-boundary splitting was considered and rejected, keeping `chunker.ts` dependency-free per ADR 0007. Full rationale: https://claude.ai/code/artifact/e975a405-3bb9-4cbf-8b3a-a7311592f664

Fixes #87. Follow-up (heading-only-first-chunk case, deliberately out of scope): #93.

## Test plan
- [x] `npx vitest run lib/rag/chunker.test.ts` — 9/9 pass (5 existing unchanged + 4 new covering: whitespace-boundary split, no-whitespace hard-cut fallback, heading-carry across split fragments, overlap-carry across split fragments)
- [x] `npx vitest run` — full suite green except one pre-existing, unrelated `embeddings.test.ts` env failure (reproduced on baseline before this change)
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run format` (no changes)
- [x] `npm run check:fallow` — no issues in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)